### PR TITLE
Fix expression injection in composite actions

### DIFF
--- a/actions/rubric-check/action.yml
+++ b/actions/rubric-check/action.yml
@@ -26,18 +26,23 @@ runs:
   steps:
     - name: Verify binary exists
       shell: bash
+      env:
+        INPUT_CLI_BINARY: ${{ inputs.cli-binary }}
       run: |
-        if [ ! -x "${{ inputs.cli-binary }}" ]; then
-          echo "::error::CLI binary not found or not executable: ${{ inputs.cli-binary }}"
+        if [ ! -x "$INPUT_CLI_BINARY" ]; then
+          echo "::error::CLI binary not found or not executable: $INPUT_CLI_BINARY"
           exit 1
         fi
 
     - name: Score rubric
       id: score
       shell: bash
+      env:
+        INPUT_CLI_BINARY: ${{ inputs.cli-binary }}
+        INPUT_PROFILE: ${{ inputs.profile }}
       run: |
-        BINARY="${{ inputs.cli-binary }}"
-        PROFILE="${{ inputs.profile }}"
+        BINARY="$INPUT_CLI_BINARY"
+        PROFILE="$INPUT_PROFILE"
         PASSED=0
         FAILED=0
         TOTAL=0

--- a/actions/rubric-check/action.yml
+++ b/actions/rubric-check/action.yml
@@ -30,7 +30,7 @@ runs:
         INPUT_CLI_BINARY: ${{ inputs.cli-binary }}
       run: |
         if [ ! -x "$INPUT_CLI_BINARY" ]; then
-          echo "::error::CLI binary not found or not executable: $INPUT_CLI_BINARY"
+          echo "ERROR: CLI binary not found or not executable: $INPUT_CLI_BINARY" >&2
           exit 1
         fi
 

--- a/actions/surface-compat/action.yml
+++ b/actions/surface-compat/action.yml
@@ -27,11 +27,11 @@ runs:
         INPUT_BASELINE: ${{ inputs.baseline }}
       run: |
         if [ ! -x "$INPUT_CLI_BINARY" ]; then
-          echo "::error::CLI binary not found: $INPUT_CLI_BINARY"
+          echo "ERROR: CLI binary not found: $INPUT_CLI_BINARY" >&2
           exit 1
         fi
         if [ ! -f "$INPUT_BASELINE" ]; then
-          echo "::error::Baseline file not found: $INPUT_BASELINE"
+          echo "ERROR: Baseline file not found: $INPUT_BASELINE" >&2
           exit 1
         fi
 
@@ -53,7 +53,7 @@ runs:
 
           local json
           json=$("$BINARY" "${args[@]}" --help --agent 2>/dev/null) || {
-            echo "::warning::--help --agent failed for: $cmd_path"
+            echo "WARNING: --help --agent failed for: $cmd_path" >&2
             return 0
           }
 

--- a/actions/surface-compat/action.yml
+++ b/actions/surface-compat/action.yml
@@ -22,21 +22,26 @@ runs:
   steps:
     - name: Verify inputs
       shell: bash
+      env:
+        INPUT_CLI_BINARY: ${{ inputs.cli-binary }}
+        INPUT_BASELINE: ${{ inputs.baseline }}
       run: |
-        if [ ! -x "${{ inputs.cli-binary }}" ]; then
-          echo "::error::CLI binary not found: ${{ inputs.cli-binary }}"
+        if [ ! -x "$INPUT_CLI_BINARY" ]; then
+          echo "::error::CLI binary not found: $INPUT_CLI_BINARY"
           exit 1
         fi
-        if [ ! -f "${{ inputs.baseline }}" ]; then
-          echo "::error::Baseline file not found: ${{ inputs.baseline }}"
+        if [ ! -f "$INPUT_BASELINE" ]; then
+          echo "::error::Baseline file not found: $INPUT_BASELINE"
           exit 1
         fi
 
     - name: Generate current surface
       shell: bash
+      env:
+        INPUT_CLI_BINARY: ${{ inputs.cli-binary }}
       run: |
         # Walk the CLI command tree and produce surface snapshot
-        BINARY="${{ inputs.cli-binary }}"
+        BINARY="$INPUT_CLI_BINARY"
         ROOT_NAME=$(basename "$BINARY")
 
         walk_commands() {
@@ -72,8 +77,10 @@ runs:
     - name: Diff surfaces
       id: diff
       shell: bash
+      env:
+        INPUT_BASELINE: ${{ inputs.baseline }}
       run: |
-        BASELINE="${{ inputs.baseline }}"
+        BASELINE="$INPUT_BASELINE"
         CURRENT="/tmp/surface-current.txt"
 
         # comm requires sorted input — sort both with consistent locale


### PR DESCRIPTION
## Summary

- Move `${{ inputs.* }}` interpolations from `run:` blocks to `env:` blocks in both `rubric-check` and `surface-compat` composite actions
- Values are now set as environment variables by the runner before bash executes, preventing shell injection via crafted input values

These actions are consumed by our `*-cli` repos, where workflows run on user-submitted PRs. A malicious PR author could craft input values containing shell metacharacters that break out of the interpolation context. The `env:` pattern eliminates this class entirely.

Resolves all 10 CodeQL `actions/code-injection` alerts (1–10).

## Test plan

- [x] `make check` passes
- [ ] CodeQL re-scan closes all 10 alerts
- [ ] `grep` confirms no `${{ inputs.` remains in any `run:` block