### PR TITLE
Fix benchstat install in CI benchmarks job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install benchstat
         if: steps.filter.outputs.bench == 'true'
-        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20250207232725-2c7781eb8b4a
+        run: go install golang.org/x/perf/cmd/benchstat@latest
 
       - name: Compare benchmarks
         if: steps.filter.outputs.bench == 'true' && hashFiles('benchmarks-baseline.txt') != ''


### PR DESCRIPTION
## Summary
- The pinned benchstat pseudo-version (`v0.0.0-20250207232725-2c7781eb8b4a`) referenced a nonexistent commit, causing the Benchmarks job to fail
- Switched to `@latest`, consistent with basecamp-cli and the seed template

## Test plan
- [x] Benchmarks job passes in CI