### PR TITLE
Security hardening Phase 3: env gate, scorecard, seed templates

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   classify:
-    uses: basecamp/.github/.github/workflows/ai-classify-pr.yml@fc560544cd2bb4e242530bde9b0d9deb7863ea45
+    uses: basecamp/.github/.github/workflows/ai-classify-pr.yml@0f236fea0ac36da812ff7178af3af1b4ee686c3c
     with:
       prompt-file: .github/prompts/classify-pr.prompt.yml
       labels: "bug,enhancement,documentation"
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
 
   breaking:
-    uses: basecamp/.github/.github/workflows/ai-breaking-change.yml@fc560544cd2bb4e242530bde9b0d9deb7863ea45
+    uses: basecamp/.github/.github/workflows/ai-breaking-change.yml@0f236fea0ac36da812ff7178af3af1b4ee686c3c
     with:
       prompt-file: .github/prompts/detect-breaking.prompt.yml
       file-patterns: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   security-events: write
@@ -75,6 +79,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: [test, security]
+    environment: release
     permissions:
       contents: write
       models: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+      - uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
+        continue-on-error: true
         with:
           sarif_file: results.sarif

--- a/seed/.github/workflows/release.yml
+++ b/seed/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
       models: read
     env:
       HAS_MACOS_SIGNING: ${{ secrets.MACOS_SIGN_P12 && 'true' || '' }}

--- a/seed/.github/workflows/release.yml
+++ b/seed/.github/workflows/release.yml
@@ -5,9 +5,14 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
+  attestations: write
   security-events: write
   pull-requests: read
   models: read
@@ -286,7 +291,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.14.1'
           install-only: true
 
       - name: Run GoReleaser
@@ -306,6 +311,11 @@ jobs:
           fi
           export RELEASE_CHANGELOG
           goreleaser release --clean
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-checksums-file: ./dist/checksums.txt
 
       # Configure secrets.AUR_SSH_KEY to enable Arch Linux AUR publishing
       - name: Publish to AUR

--- a/seed/.github/workflows/scorecard.yml
+++ b/seed/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          sarif_file: results.sarif

--- a/seed/.github/workflows/scorecard.yml
+++ b/seed/.github/workflows/scorecard.yml
@@ -33,6 +33,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+      - uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4
+        continue-on-error: true
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Add `environment: release` gate to the `publish` job in the cli release workflow
- Add `concurrency` guard to both cli and seed release workflows to prevent parallel releases
- Add OpenSSF Scorecard workflow for both cli and seed template
- Pin GoReleaser version in seed template (`v2.14.1`)
- Add `attestations: write` permission and build provenance attestation step to seed release
- Seed ai-labeler already has all `${{ }}` expressions in `env:` blocks (no changes needed)

## Test plan

- [ ] Verify `release.yml` has `environment: release` on publish job
- [ ] Verify concurrency blocks on both release workflows
- [ ] Verify scorecard workflows are valid YAML
- [ ] Verify seed release has pinned GoReleaser, attestation step, and attestations permission