### PR TITLE
Switch CODEOWNERS from sip to cli team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-* @basecamp/sip
-actions/              @basecamp/sip
-seed/                 @basecamp/sip
-.github/workflows/    @basecamp/sip
-scripts/              @basecamp/sip
+* @basecamp/cli
+actions/              @basecamp/cli
+seed/                 @basecamp/cli
+.github/workflows/    @basecamp/cli
+scripts/              @basecamp/cli


### PR DESCRIPTION
Reduces review noise for the sip team by routing ownership to the cli team.