### PR TITLE
Re-pin dependabot-sync reusable workflow past the dispatch fallback

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -33,7 +33,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@9ca40e3b2d6be769b370b7cee86e8448267c95d8
     with:
       ci-workflow-name: Test
       branch: ${{ inputs.branch || '' }}


### PR DESCRIPTION
basecamp/.github#10 removed the CI-dispatch fallback (valid Codex P1 on fizzy-cli#189: `gh workflow run <wf> --ref <dependabot-branch>` executes the branch's freshly-bumped, unreviewed action pins outside the Dependabot-restricted `pull_request` context). The reusable workflow now verifies CI started on the pushed head — which deploy-key pushes trigger normally — and warns a maintainer if not, never dispatching branch workflows. Pin bump only.