### PR TITLE
Bare pin comments + zizmor-action v0.6.0 (and the findings it surfaces)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: go.mod
 
@@ -230,6 +231,7 @@ jobs:
           private-key: ${{ secrets.SKILLS_APP_PRIVATE_KEY }}
           owner: basecamp
           repositories: skills
+          permission-contents: write
 
       - name: Sync skills
         if: steps.check.outputs.ready == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           advanced-security: false
 

--- a/seed/.github/workflows/release.yml
+++ b/seed/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in pre-release tests; environment protection would block test gate before release approval
-          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
-          permission-contents: read
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules and tap
+          permission-contents: write
           # repositories: <private-module>,homebrew-tap
 
       - name: Set up Go
@@ -150,8 +150,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
-          permission-contents: read
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules and tap
+          permission-contents: write
           # repositories: <private-module>,homebrew-tap
 
       - name: Set up Go
@@ -376,8 +376,8 @@ jobs:
         with:
           app-id: ${{ vars.SKILLS_APP_ID }}
           private-key: ${{ secrets.SKILLS_APP_PRIVATE_KEY }}
-          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
-          permission-contents: read
+          owner: basecamp
+          permission-contents: write
           repositories: skills
 
       - name: Sync skills to distribution repo

--- a/seed/.github/workflows/release.yml
+++ b/seed/.github/workflows/release.yml
@@ -44,11 +44,13 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in pre-release tests; environment protection would block test gate before release approval
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
           # repositories: <private-module>,homebrew-tap
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: 'go.mod'
 
@@ -66,7 +68,8 @@ jobs:
 
       - name: Cache BATS
         id: cache-bats
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 # zizmor: ignore[cache-poisoning] -- static cache key (bats-1.11.0) is not attacker-controllable
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        # zizmor: ignore[cache-poisoning] -- static cache key (bats-1.11.0) is not attacker-controllable
         with:
           path: /usr/local/libexec/bats-core
           key: bats-1.11.0
@@ -147,11 +150,13 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
           # repositories: <private-module>,homebrew-tap
 
       - name: Set up Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           go-version-file: 'go.mod'
 
@@ -371,7 +376,8 @@ jobs:
         with:
           app-id: ${{ vars.SKILLS_APP_ID }}
           private-key: ${{ secrets.SKILLS_APP_PRIVATE_KEY }}
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
           repositories: skills
 
       - name: Sync skills to distribution repo

--- a/seed/.github/workflows/security.yml
+++ b/seed/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -87,7 +87,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI security scans; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -147,7 +148,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI security scans; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/seed/.github/workflows/test.yml
+++ b/seed/.github/workflows/test.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
           # repositories: <private-module>
 
       - name: Set up Go
@@ -78,7 +79,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -113,7 +115,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -153,7 +156,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -189,7 +193,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -239,7 +244,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -297,7 +303,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env] -- private module token needed in CI; environment protection would block PR-triggered runs
-          owner: basecamp
+          owner: basecamp # zizmor: ignore[github-app] -- template ships disabled (RELEASE_CLIENT_ID unset); seeded repos must scope repositories: to their private modules
+          permission-contents: read
 
       - name: Check for benchmark-relevant changes
         id: filter


### PR DESCRIPTION
Part of the post-merge redesign of the comment-sync program (see basecamp/.github#10). Moving each `# zizmor: ignore[...]` to its own line below the pin makes Dependabot itself maintain the bare `# vX.Y.Z` comments — no push automation needed on its PRs.

For this repo that requires bumping zizmor-action v0.5.2 → v0.6.0 first: v0.5.2 resolves a 1.23-era zizmor that doesn't associate standalone ignore comments. The newer zizmor surfaces real issues, fixed rather than suppressed:

- **App-token scoping**: `create-github-app-token` uses gain `permission-contents` (write for the skills-sync push — `scripts/sync-skills.sh` only does `git push`; read for the seed templates' private-module access). The seed templates' owner-wide default (deliberate: ships disabled until a seeded repo scopes `repositories:`) carries an annotated ignore.
- **Dead trivy pin in seed**: `e368e328` is a commit no tag points at (why the earlier catch-up couldn't fix its comment); repinned to `ed142fd0` (v0.36.0), the fleet's SHA.
- **Seed compound comments** get the same standalone-ignore restructure.

zizmor 1.28: no findings, 22 ignored; actionlint clean.