### PR TITLE
Re-pin dependabot-sync past the bot-author fix

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -21,9 +21,9 @@ permissions: {}
 
 jobs:
   sync:
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@45d3fc9588f15d50fbccde7476418007dd19e16e
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@d7a98882c52e021fa0d4ae31e92e56d03dcce774
     permissions:
-      contents: read
+      contents: write
       actions: write
       pull-requests: write
     # The deploy key is scoped to this repo's dependabot-sync environment


### PR DESCRIPTION
basecamp/.github#12–#14 fixes discovered by the basecamp-sdk full-cycle exercise (each iteration fail-closed as designed): `app/<slug>` bot-author constant, a bounded poll for the PR API to catch up with the lease push, and `contents: write` on the job token because `enablePullRequestAutoMerge` is a contents operation (the same grant the dependabot-auto-merge workflows carry — the token still cannot push workflow files; the repair branch push stays on the environment-scoped deploy key). So: pin bump **plus** that one deliberate permission raise in the caller block. The workflow entry stays disabled until this repo's rollout turn.