### PR TITLE
Seed skills token needs issues: write for failure notifications

### DIFF
--- a/seed/.github/workflows/release.yml
+++ b/seed/.github/workflows/release.yml
@@ -378,6 +378,7 @@ jobs:
           private-key: ${{ secrets.SKILLS_APP_PRIVATE_KEY }}
           owner: basecamp
           permission-contents: write
+          permission-issues: write # failure notifications: gh issue list/comment/create on the skills repo
           repositories: skills
 
       - name: Sync skills to distribution repo


### PR DESCRIPTION
Follow-up to #53 closing the valid Codex P2: the seed template's skills App token is also the `GH_TOKEN` for the failure-notification step (`gh issue list/comment/create` on basecamp/skills), and those calls are swallowed by `|| true` — so the contents-only scoping silently killed notifications. Adds `permission-issues: write` (a documented input on the pinned create-github-app-token v2.2.1, alongside `permission-contents`).