### PR TITLE
Drop a miscounted exit-code claim and list the third prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ surface/         CLI surface snapshots and compatibility diffing
 seed/            Templates for bootstrapping new CLIs
 actions/         Reusable GitHub Actions (rubric-check, surface-compat, sync-skills)
 skills/          Agent skills distributed via basecamp/skills
-prompts/         Agent prompts (seed-cli.md, close-gap.md)
+prompts/         Agent prompts (seed-cli.md, close-gap.md, close-input-gap.md)
 
 RUBRIC.md        37signals CLI rubric specification
 Makefile         Build and test targets
@@ -27,7 +27,7 @@ All packages import from `github.com/basecamp/cli/<package>`.
 
 | Package | Purpose |
 |---------|---------|
-| `output` | JSON response/error envelopes, 8 typed exit codes (0–8), TTY auto-detection |
+| `output` | JSON response/error envelopes, typed exit codes (see `output/codes.go`), TTY auto-detection |
 | `credstore` | System keyring with file fallback (0600); caller-configured `DisableEnvVar` forces file mode |
 | `pkce` | `GenerateVerifier()` and `GenerateChallenge()` for OAuth PKCE flows |
 | `oauthcallback` | `WaitForCallback()` starts local server, returns authorization code |


### PR DESCRIPTION
"8 typed exit codes (0–8)" is nine codes: output/codes.go defines ExitOK
through ExitAmbiguous, 0 to 8 inclusive. Rather than correct 8 to 9 and leave
a number to drift the next time a code is added, the count is replaced by a
pointer to the file that defines them.

prompts/ was described as two files and holds three -- close-input-gap.md was
missing.


---
Checked against `main` at 04e401b12c6ccdd4606844bcb328d197ab3da250.
