### PR TITLE
Normalize the trivy-action version comment to the v-prefixed tag

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
This unblocks the `GitHub Actions audit` failure on #63.

`aquasecurity/trivy-action` published **both** `0.35.0` and `v0.35.0` for that release, so our bare `# 0.35.0` comment still resolves and main audits clean today. It stopped publishing the bare alias at 0.36.0 — only `v0.36.0` exists:

```
refs/tags/0.35.0
refs/tags/v0.34.0
refs/tags/v0.35.0
refs/tags/v0.36.0
```

Dependabot carries the existing comment style forward, so on #63 it writes `# 0.36.0`, and zizmor's `ref-version-mismatch` — new in 1.29.0, which #63 pulls in by bumping zizmor-action v0.6.0 → v0.6.2 — correctly flags it as *"points to unknown ref ... is pointed to by tag v0.36.0"*. That single medium finding is the only thing failing #63; its other 15 checks pass.

Fixing the style here rather than in the bump is deliberate: dependabot then picks up the `v` prefix on this and every future trivy bump, instead of the same finding recurring each time. It also avoids pushing to a Dependabot branch — per the note in `basecamp/.github`'s `dependabot-sync-actions-comments.yml`, any non-Dependabot push to such a PR flips the actor on the retriggered `pull_request` runs and lifts GitHub's Dependabot sandbox over freshly bumped, unreviewed action pins.

**`57a97c7e` is the same commit under both tags, so the pin is unchanged** — comment only. Verified with `zizmor --persona=regular` (online) 1.29.0 against this tree: no findings.

Once this lands, rebasing #63 should take it green.