### PR TITLE
Pin the Go toolchain to 1.26.7 to clear three stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/cli
 
-go 1.26
+go 1.26.7
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
`Govulncheck` started failing on **every** open PR in this repo today. Three Go standard library advisories, all reachable from our code, all fixed in go1.26.6:

| ID | Package | Fixed in |
|---|---|---|
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` | go1.26.6 |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` | go1.26.6 |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` | go1.26.6 |

**Nothing in the source changed.** `go.mod` carried a bare `go 1.26`, which setup-go reads as `>=1.26.0 <1.27` and satisfies from the runner's tool cache rather than downloading a newer patch — `Found in cache @ /opt/hostedtoolcache/go/1.26.5/x64`. That was fine until the advisories landed against 1.26.5; from that moment every build inherited a vulnerable toolchain.

That's also why this looked like it appeared out of nowhere: #63's `Govulncheck` **passed** at 09:24 today, and re-running that same job on the same commit an hour later failed. Time-based, not tree-based.

### Why patch-pin the `go` directive

All eight `setup-go` steps across `test.yml`, `security.yml` and `release.yml` use `go-version-file: go.mod`, so one line covers every one of them. Pinning the patch makes the resolved version exact instead of "newest thing already in the cache".

It also matches the rest of the fleet — `kamal-proxy` (`go 1.26.5`), `once` (`go 1.26.4`) and `basecamp-installer` (`go 1.26.4`) all patch-pin the `go` directive and carry no `toolchain` directive. cli was the outlier with a bare minor.

I considered `check-latest: true` on the setup-go steps instead, which would self-heal on the next advisory. It's eight edits rather than one, and it trades reproducible builds for a floating toolchain — worth doing deliberately if you want it, but not the minimal fix for a red CI.

### Verification

Reproduced and confirmed locally against this exact tree:

```
go1.26.5 → 3 vulnerabilities (the three above)
go1.26.6 → No vulnerabilities found.
go1.26.7 → No vulnerabilities found.
```

`go build`, `go vet`, `gofmt -l` and the full `go test ./...` suite all pass on 1.26.7.

### Note

Dependabot will not maintain this pin — its `gomod` updater doesn't bump the `go` directive, which is why kamal-proxy still sits on 1.26.5 while 1.26.7 is out. The next stdlib advisory will need the same manual bump here and in those three repos. Worth a separate conversation about whether `check-latest: true` is the better standing answer fleet-wide.

Once this lands, #64 and #63 should go green on rebase.