### PR TITLE
Let dependabot maintain the seed workflows too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,13 @@ updates:
 
   # GitHub Actions
   - package-ecosystem: github-actions
-    directory: "/"
+    # The seed workflows are copied verbatim into every generated CLI
+    # (prompts/seed-cli.md), so they need updating like any other workflow.
+    # For github-actions a non-root entry is scanned directly for *.yml, so the
+    # path is the workflows directory itself rather than the tree above it.
+    directories:
+      - "/"
+      - "/seed/.github/workflows"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
Closes the drift Copilot spotted on #63, at the source rather than by syncing copies.

`prompts/seed-cli.md` copies `seed/.github/workflows/*` verbatim into every generated CLI, but Dependabot only ever saw the root, so the templates fell behind our own workflows:

```
live  .github/workflows/test.yml:  actions/checkout v7.0.1   actions/setup-go v7.0.0
seed  .github/workflows/test.yml:  actions/checkout v6.0.2   actions/setup-go v6.3.0
```

### Why `directories` works here

GitHub's option reference says *"For GitHub Actions, use the value `/`"*, which reads like a restriction — it isn't; it describes the root case. `dependabot-core`'s `github_actions/file_fetcher.rb` branches on it:

```ruby
if directory == "/"
  workflows_dir = WORKFLOW_DIRECTORY   # ".github/workflows"
else
  workflows_dir = "."                  # the directory itself is scanned for *.yml
end
```

and its own spec covers the non-root case directly:

```ruby
context "when an explicit directory is given" do
  let(:directory) { "/.github/workflows" }
  it "fetches the workflow files relatively to the directory" do
```

So the entry has to name the workflows directory itself. `"/seed"` would scan `seed/*.yml` and match nothing, which is probably why this looks unsupported at a glance.

### Why this rather than a sync check

The obvious alternatives are a CI check that seed pins equal live pins, or generating the seed from the live workflows. Both are worse: the first adds friction to every action bump forever, the second is a rewrite. Letting the updater own the files costs two lines and no ongoing work — the seed group will simply appear in the weekly grouped PR alongside the root one.

### Severity, honestly

Low. `seed/.github/dependabot.yml` is itself copied into generated projects and configures `github-actions` weekly, so a new CLI catches up on its first run — the stale window is bounded, not permanent. And neither lagging pin (`checkout` v6.0.2, `setup-go` v6.3.0) carries a known advisory. This is about not shipping a stale starting point, not about exposure.

`zizmor --collect=all` is clean across the tree, seed workflows included. No workflow behaviour changes here — only which files Dependabot looks at.
